### PR TITLE
Features/pattern match support

### DIFF
--- a/backends.go
+++ b/backends.go
@@ -11,17 +11,32 @@ import (
 	"github.com/Microkubes/microservice-tools/config"
 )
 
+// Filter is a map property => value/pattern to match the DB entries against.
 type Filter map[string]interface{}
 
+// NewFilter is a builder method to create new filter.
+// All filter methods are chained, so you can convinientry do somethind like this:
+// 		filter := backends.NewFilter().MatchPattern("name", "John%").Match("role", "user")
 func NewFilter() Filter {
 	return Filter{}
 }
 
+// Match sets an exact match for a given property.
+// For example:
+// 		filter := backends.NewFilter().Match("id", "0001")
+// would match the entry with ID equals to "0001".
 func (f Filter) Match(property string, value interface{}) Filter {
 	f[property] = value
 	return f
 }
 
+// MatchPattern sets a pattern match for the given property.
+// The match works similar to how 'LIKE' pattern matching works
+// in SQL:
+// "%a" matches "ba", "tada" but not "ab"
+// "a%" matches "ab" but not "ba"
+// "%ab%" matches anything that contains "ab"
+// "ab" does an exact match to "ab"
 func (f Filter) MatchPattern(property, value string) Filter {
 	f[property] = map[string]string{
 		"$pattern": value,
@@ -29,6 +44,7 @@ func (f Filter) MatchPattern(property, value string) Filter {
 	return f
 }
 
+// Set is an alias for Filter.Match - do an exact match on the given property.
 func (f Filter) Set(property string, value interface{}) Filter {
 	f[property] = value
 	return f

--- a/backends.go
+++ b/backends.go
@@ -22,6 +22,13 @@ func (f Filter) Match(property string, value interface{}) Filter {
 	return f
 }
 
+func (f Filter) MatchPattern(property, value string) Filter {
+	f[property] = map[string]string{
+		"$pattern": value,
+	}
+	return f
+}
+
 func (f Filter) Set(property string, value interface{}) Filter {
 	f[property] = value
 	return f

--- a/dynamodb_test.go
+++ b/dynamodb_test.go
@@ -1,0 +1,196 @@
+package backends
+
+import (
+	"testing"
+)
+
+func TestTokenize(t *testing.T) {
+	tokens := tokenize("abcde")
+	if tokens == nil || len(tokens) != 1 {
+		t.Fatal("expected one token")
+	}
+	if tokens[0] != "abcde" {
+		t.Fatal("invalid tokens")
+	}
+
+	tokens = tokenize("%abcde")
+	if tokens == nil || len(tokens) != 1 {
+		t.Fatal("expected one token")
+	}
+	if tokens[0] != "abcde" {
+		t.Fatal("invalid tokens. Got: ", tokens)
+	}
+
+	tokens = tokenize("abcde%")
+	if tokens == nil || len(tokens) != 1 {
+		t.Fatal("expected one token")
+	}
+	if tokens[0] != "abcde" {
+		t.Fatal("invalid tokens. Got: ", tokens)
+	}
+
+	tokens = tokenize("%abcde%")
+	if tokens == nil || len(tokens) != 1 {
+		t.Fatal("expected one token")
+	}
+	if tokens[0] != "abcde" {
+		t.Fatal("invalid tokens. Got: ", tokens)
+	}
+
+	tokens = tokenize("%%abcde")
+	if tokens == nil || len(tokens) != 1 {
+		t.Fatal("expected one token")
+	}
+	if tokens[0] != "%abcde" {
+		t.Fatal("invalid tokens. Got: ", tokens)
+	}
+
+	tokens = tokenize("abcde%%")
+	if tokens == nil || len(tokens) != 1 {
+		t.Fatal("expected one token")
+	}
+	if tokens[0] != "abcde%" {
+		t.Fatal("invalid tokens. Got: ", tokens)
+	}
+
+	tokens = tokenize("ab%de")
+	if len(tokens) != 2 {
+		t.Fatal("Expected 2 tokens. Got: ", len(tokens), tokens)
+	}
+
+	if !strArrEq(tokens, []string{"ab", "de"}) {
+		t.Fatal("Invalid tokens. Got: ", tokens)
+	}
+
+	tokens = tokenize("ab%de%gh")
+	if len(tokens) != 3 {
+		t.Fatal("Expected 3 tokens. Got: ", len(tokens), tokens)
+	}
+
+	if !strArrEq(tokens, []string{"ab", "de", "gh"}) {
+		t.Fatal("Invalid tokens. Got: ", tokens)
+	}
+
+}
+
+func strArrEq(a, b []string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, av := range a {
+		if av != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func patternCondArrEqual(a, b []*patternCondition) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, av := range a {
+		if !av.Equals(b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func TestPatternToDynamoDBCondition(t *testing.T) {
+
+	conds := patternToDynamodbCondition("abcd")
+	if conds == nil || len(conds) != 1 {
+		t.Fatal("Expected 1 condition to be parsed.")
+	}
+	if !conds[0].Equals(&patternCondition{
+		condition: "EQ",
+		value:     "abcd",
+	}) {
+		t.Fatal("Invalid condition. Got: ", conds[0])
+	}
+
+	conds = patternToDynamodbCondition("%abcd")
+	if conds == nil || len(conds) != 1 {
+		t.Fatal("Expected 1 condition to be parsed.")
+	}
+	if !conds[0].Equals(&patternCondition{
+		condition: "CONTAINS",
+		value:     "abcd",
+	}) {
+		t.Fatal("Invalid condition. Got: ", conds[0])
+	}
+
+	conds = patternToDynamodbCondition("%abcd%")
+	if conds == nil || len(conds) != 1 {
+		t.Fatal("Expected 1 condition to be parsed.")
+	}
+	if !conds[0].Equals(&patternCondition{
+		condition: "CONTAINS",
+		value:     "abcd",
+	}) {
+		t.Fatal("Invalid condition. Got: ", conds[0])
+	}
+
+	conds = patternToDynamodbCondition("abcd%")
+	if conds == nil || len(conds) != 1 {
+		t.Fatal("Expected 1 condition to be parsed.")
+	}
+	if !conds[0].Equals(&patternCondition{
+		condition: "BEGINS_WITH",
+		value:     "abcd",
+	}) {
+		t.Fatal("Invalid condition. Got: ", conds[0])
+	}
+
+	conds = patternToDynamodbCondition("%%abcd")
+	if conds == nil || len(conds) != 1 {
+		t.Fatal("Expected 1 condition to be parsed.")
+	}
+	if !conds[0].Equals(&patternCondition{
+		condition: "EQ",
+		value:     "%abcd",
+	}) {
+		t.Fatal("Invalid condition. Got: ", conds[0])
+	}
+
+	conds = patternToDynamodbCondition("%%abcd%%")
+	if conds == nil || len(conds) != 1 {
+		t.Fatal("Expected 1 condition to be parsed.")
+	}
+	if !conds[0].Equals(&patternCondition{
+		condition: "EQ",
+		value:     "%abcd%",
+	}) {
+		t.Fatal("Invalid condition. Got: ", conds[0])
+	}
+
+	conds = patternToDynamodbCondition("%%ab%cd%%")
+	if conds == nil || len(conds) != 2 {
+		t.Fatal("Expected 2 conditions to be parsed.")
+	}
+	if patternCondArrEqual(conds, []*patternCondition{
+		&patternCondition{
+			condition: "BEGINS_WITH",
+			value:     "%ab",
+		},
+		&patternCondition{
+			condition: "CONTAINS",
+			value:     "cd%",
+		},
+	}) {
+		t.Fatal("Invalid conditions. Got: ", conds)
+	}
+}

--- a/mongodb.go
+++ b/mongodb.go
@@ -388,7 +388,9 @@ func toMongoFilter(filter Filter) (map[string]interface{}, error) {
 		if specs, ok := value.(map[string]interface{}); ok {
 			if pattern, ok := specs["$pattern"]; ok {
 				mongoPattern := toMongoPattern(pattern.(string))
-				mgf[key] = mongoPattern
+				mgf[key] = bson.M{
+					"$regex": mongoPattern,
+				}
 				continue
 			}
 			return nil, fmt.Errorf("unknown filter specification - supported type is $pattern")

--- a/mongodb.go
+++ b/mongodb.go
@@ -206,7 +206,12 @@ func (c *MongoCollection) GetAll(filter Filter, resultsTypeHint interface{}, ord
 		}
 	}
 
-	query := c.Find(filter)
+	mongoFilter, err := toMongoFilter(filter)
+	if err != nil {
+		return nil, ErrInvalidInput(err)
+	}
+
+	query := c.Find(mongoFilter)
 	if order != "" {
 		if sorting == "desc" {
 			order = "-" + order
@@ -220,7 +225,7 @@ func (c *MongoCollection) GetAll(filter Filter, resultsTypeHint interface{}, ord
 		query = query.Limit(limit)
 	}
 
-	err := query.All(slicePointer.Interface())
+	err = query.All(slicePointer.Interface())
 	if err != nil {
 		if err == mgo.ErrNotFound {
 			return nil, ErrNotFound(err)
@@ -374,4 +379,54 @@ func (c *MongoCollection) DeleteAll(filter Filter) error {
 	}
 
 	return nil
+}
+
+func toMongoFilter(filter Filter) (map[string]interface{}, error) {
+	mgf := map[string]interface{}{}
+
+	for key, value := range filter {
+		if specs, ok := value.(map[string]interface{}); ok {
+			if pattern, ok := specs["$pattern"]; ok {
+				mongoPattern := toMongoPattern(pattern.(string))
+				mgf[key] = mongoPattern
+				continue
+			}
+			return nil, fmt.Errorf("unknown filter specification - supported type is $pattern")
+		}
+		mgf[key] = value // copy over the key=>value pairs to do exact matching
+	}
+
+	return mgf, nil
+}
+
+func toMongoPattern(pattern string) string {
+	mongoPattern := ""
+
+	prev := '\000'
+
+	for _, r := range pattern {
+		if r == '%' {
+			if prev == '%' {
+				mongoPattern += "%"
+				prev = '\000'
+				continue
+			}
+			prev = r
+			continue
+		}
+		if prev == '%' {
+			mongoPattern += ".*"
+		}
+		if r != '\000' {
+			mongoPattern += string(r)
+		}
+
+		prev = r
+	}
+	if prev == '%' {
+		// at the very end of the pattern
+		mongoPattern += ".*"
+	}
+
+	return mongoPattern
 }

--- a/mongodb_test.go
+++ b/mongodb_test.go
@@ -1,0 +1,41 @@
+package backends
+
+import "testing"
+
+func TestToMongoPattern(t *testing.T) {
+	pattern := toMongoPattern("not-changed")
+	if pattern != "not-changed" {
+		t.Fatal("Expected the pattern to be unchanged. Got: ", pattern)
+	}
+
+	pattern = toMongoPattern("in the %middle")
+	if pattern != "in the .*middle" {
+		t.Fatal("Expected the pattern to be in the middle. Got: ", pattern)
+	}
+
+	pattern = toMongoPattern("%at beginning")
+	if pattern != ".*at beginning" {
+		t.Fatal("Expected the pattern to be at the beginning. Got: ", pattern)
+	}
+
+	pattern = toMongoPattern("at end%")
+	if pattern != "at end.*" {
+		t.Fatal("Expected the pattern to be at the end. Got: ", pattern)
+	}
+
+	pattern = toMongoPattern("%start%middle and end%")
+	if pattern != ".*start.*middle and end.*" {
+		t.Fatal("Expected the pattern to be on multiple places. Got: ", pattern)
+	}
+
+	pattern = toMongoPattern("escape %% it")
+	if pattern != "escape % it" {
+		t.Fatal("Expected the pattern to escaped. Got: ", pattern)
+	}
+
+	pattern = toMongoPattern("triple %%%")
+	if pattern != "triple %.*" {
+		t.Fatal("Expected the pattern to be at the end. Got: ", pattern)
+	}
+
+}


### PR DESCRIPTION
Adds pattern matching capabilities to the ```backends.Filter``` type.
It works very similar to ```SQL``` ```LIKE``` expression:
 * ```filter.MatchPattern("name", "%ab%")``` - matches every ```"name"``` that contains ```"ab"```
 * ```filter.MatchPattern("name", "ab%")``` - matches every ```"name"``` that starts with ```"ab"```
 * ```filter.MatchPattern("name", "%ab")``` - matches every ```"name"``` that ends in ```"ab"``` (although this would translate to every name that contains ```"ab"``` for DynamoDB as it does not support ENDS WITH clause).
 * ```filter.MatchPattern("name", "%%ab%")``` - matches every ```"name"``` that starts with ```"%ab"``` - NOTE that "%%" translates to "%" .
To match ```"%"``` (literal), you need to specify ```"%%"```.